### PR TITLE
Make Hero banner responsive on smaller device.

### DIFF
--- a/docroot/themes/custom/camp/scss/Components/Hero/_hero.scss
+++ b/docroot/themes/custom/camp/scss/Components/Hero/_hero.scss
@@ -11,10 +11,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   @include mobile{
-    height: 63vh;
-  }
-  @include mobile_M{
-    height: 80vh;
+    height: auto;
   }
 }
 
@@ -27,6 +24,9 @@
   @include mobile{
     margin: 0px 16px;
     text-align: center;
+    position: relative;
+    transform: none;
+    padding: 40px 0;
   }
   .text-field-title{
     font-size: 72px;


### PR DESCRIPTION
Before:
<img width="974" alt="Screenshot 2023-06-22 at 6 42 10 PM" src="https://github.com/drupalpune/campsite/assets/74306970/479c5488-35f6-4b59-9894-c5e17b253f13">

After:
<img width="690" alt="Screenshot 2023-06-22 at 6 42 26 PM" src="https://github.com/drupalpune/campsite/assets/74306970/6d33b79d-8710-44dd-8ac7-f8a72866d5fb">
