### PR TITLE
Issue-158 : Fix Author and Co-presenter details

### DIFF
--- a/docroot/themes/custom/camp/templates/node/node--session--schedule.html.twig
+++ b/docroot/themes/custom/camp/templates/node/node--session--schedule.html.twig
@@ -12,13 +12,15 @@
   {{ title_prefix }}
   {{ title_suffix }}
   <div class="schedule__session--title">
-    <a href={{ url }}>{{ label }}</a>
+    <a href={{ url }} class ="text-7xl font-bold">{{ label }}</a>
   </div>
   <div class="schedule__session--author-detail">
-    {{ 'By '|t }}{{ node.Owner.field_full_name.value }}
-    {% if content.field_co_presenter.0 is not empty %}
-      {{ ', ' ~ content.field_co_presenter.0["#account"].field_full_name.value }}
-    {% endif %}
+    {{ 'By '|t }}{{ node.Owner.field_full_name.value|join }}
+    {% for item in content.field_co_presenter %}
+      {% if item is iterable and item["#account"].field_full_name.value is not empty %}
+        {{ ', ' ~ item["#account"].field_full_name.value|join }}
+      {% endif %}
+    {% endfor %}
   </div>
   <div class="schedule__session--category">
     {{ content.field_session_category_.0["#title"] }}


### PR DESCRIPTION
In this PR, we fixed the Author and Co-presenter details which shows on schedule page.
Also I have checked the page in Incognito mode, it looks fine. Also have fixed the session title link.

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/6dda46d8-291f-430c-9da5-4c813f24e5ea">


Let me know if there are any other feedbacks!